### PR TITLE
Namespace Mismatch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "autoload": {
     "psr-4": {
-      "Imagewize\\SageNativeBlock\\": "src/"
+      "Imagewize\\SageNativeBlockPackage\\": "src/"
     }
   },
   "require": {
@@ -20,10 +20,10 @@
   "extra": {
     "acorn": {
       "providers": [
-        "Imagewize\\SageNativeBlock\\Providers\\SageNativeBlockServiceProvider"
+        "Imagewize\\SageNativeBlockPackage\\Providers\\SageNativeBlockServiceProvider"
       ],
       "aliases": {
-        "SageNativeBlock": "Imagewize\\SageNativeBlock\\Facades\\SageNativeBlock"
+        "SageNativeBlock": "Imagewize\\SageNativeBlockPackage\\Facades\\SageNativeBlock"
       }
     }
   }


### PR DESCRIPTION
This pull request updates the namespace and related references in the `composer.json` file to align with a new naming convention for the package. The changes ensure consistency in the namespace and improve clarity.

Namespace updates in `composer.json`:

* Updated the `psr-4` autoload namespace from `Imagewize\SageNativeBlock\` to `Imagewize\SageNativeBlockPackage\`.
* Updated the service provider reference in the `acorn.providers` section to use the new namespace: `Imagewize\SageNativeBlockPackage\Providers\SageNativeBlockServiceProvider`.
* Updated the alias for `SageNativeBlock` in the `acorn.aliases` section to reflect the new namespace: `Imagewize\SageNativeBlockPackage\Facades\SageNativeBlock`.