### PR TITLE
License Update

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,4 @@
+Copyright (c) 2025 Imagewize
 Copyright (c) Roots Software LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of


### PR DESCRIPTION
This pull request updates the licensing information in the `LICENSE.md` file to reflect the current copyright holder.

* [`LICENSE.md`](diffhunk://#diff-4673a3aba01813b595de187a7a6e9e63a3491d55821606fecd9f13a10c188a1dR1): Updated the copyright holder to "Imagewize" for 2025.