### PR TITLE
General Clarifications & Improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,46 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  php:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    strategy:
+      matrix:
+        php: ['8.2']
+
+    steps:
+      - name: Checkout the project
+        uses: actions/checkout@v4
+
+      - name: Setup the PHP ${{ matrix.php }} environment on ${{ runner.os }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: xdebug
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore the Composer cache directory
+        id: composercache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.composercache.outputs.dir }}
+          key: ${{ runner.os }}-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.php }}-composer-
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader --no-suggest
+
+      - name: Run Pint
+        run: vendor/bin/pint --test

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ composer require imagewize/sage-native-block
 You can publish the config file with:
 
 ```shell
-$ wp acorn vendor:publish --provider="Imagewize\SageNativeBlockPackage\Providers\SageNativeBlockServiceProvider"
+wp acorn vendor:publish --provider="Imagewize\SageNativeBlockPackage\Providers\SageNativeBlockServiceProvider"
 ```
 
 ## Usage
@@ -32,7 +32,7 @@ $ wp acorn vendor:publish --provider="Imagewize\SageNativeBlockPackage\Providers
 Run the sage-native-block command to create a block with default settings:
 
 ```shell
-$ wp acorn sage-native-block:add-setup
+wp acorn sage-native-block:add-setup
 ```
 
 This will:
@@ -45,7 +45,7 @@ This will:
 To create a block with a custom name:
 
 ```shell
-$ wp acorn sage-native-block:add-setup my-cool-block
+wp acorn sage-native-block:add-setup my-cool-block
 ```
 
 This will create a block named `vendor/my-cool-block` with all the necessary files.

--- a/README.md
+++ b/README.md
@@ -19,13 +19,6 @@ You can install this package with Composer:
 composer require imagewize/sage-native-block
 ```
 
-You can publish the config file with:
-
-```shell
-wp acorn vendor:publish --provider="Imagewize\SageNativeBlockPackage\Providers\SageNativeBlockServiceProvider" --tag="config"
-```
-**NB** Currently not necessary as we don't have any config options yet.
-
 ## Configuration
 
 You can publish the config file with:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ composer require imagewize/sage-native-block
 You can publish the config file with:
 
 ```shell
-wp acorn vendor:publish --provider="Imagewize\SageNativeBlockPackage\Providers\SageNativeBlockServiceProvider"
+wp acorn vendor:publish --provider="Imagewize\SageNativeBlockPackage\Providers\SageNativeBlockServiceProvider" --tag="config"
 ```
+**NB** Currently not necessary as we don't have any config options yet.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,48 @@ wp acorn vendor:publish --provider="Imagewize\SageNativeBlockPackage\Providers\S
 ```
 **NB** Currently not necessary as we don't have any config options yet.
 
+## Configuration
+
+You can publish the config file with:
+
+```shell
+wp acorn vendor:publish --provider="Imagewize\SageNativeBlockPackage\Providers\SageNativeBlockServiceProvider" --tag="config"
+```
+
+After publishing the configuration, you can customize the following options in `config/sage-native-block.php`:
+
+### Default Vendor Prefix
+
+```php
+'default_vendor_prefix' => 'vendor',
+```
+
+This sets the default vendor prefix used when creating blocks without a specified vendor prefix. Instead of manually typing your vendor prefix each time, you can set it once in the config.
+
+### Block Directory Path
+
+```php
+'block_directory' => 'resources/js/blocks',
+```
+
+This defines where block files will be created within your Sage theme. By default, blocks are placed in `resources/js/blocks`, but you can customize this to your preferred location.
+
+### Template Customization
+
+```php
+'templates' => [
+    'block_json' => null,    // Path to custom block.json template
+    'index_js' => null,      // Path to custom index.js template
+    'editor_jsx' => null,    // Path to custom editor.jsx template
+    'save_jsx' => null,      // Path to custom save.jsx template
+    'editor_css' => null,    // Path to custom editor.css template
+    'style_css' => null,     // Path to custom style.css template
+    'view_js' => null,       // Path to custom view.js template
+],
+```
+
+Each template can be customized by providing a path to your own version. This allows you to create blocks with your own standardized structure, coding patterns, or additional features.
+
 ## Usage
 
 ### Creating a new block
@@ -69,6 +111,18 @@ Use the `--force` flag to skip the confirmation prompt:
 $ wp acorn sage-native-block:add-setup --force
 $ wp acorn sage-native-block:add-setup my-block-name --force
 $ wp acorn sage-native-block:add-setup imagewize/custom-block --force
+```
+
+## Command Options
+
+When creating blocks, you can override the defaults set in the configuration:
+
+```shell
+# Using configuration defaults
+wp acorn sage-native-block:add-setup my-block
+
+# Override the vendor prefix from command line
+wp acorn sage-native-block:add-setup my-block --vendor=custom-vendor
 ```
 
 ## Block Structure

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": "^8.1"
   },
   "require-dev": {
-    "laravel/pint": "^1.20"
+    "laravel/pint": "^1.22"
   },
   "extra": {
     "acorn": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ef1a3ae523f6c1bf7ace0c7d23ecc4b3",
+    "content-hash": "31f55db7bb7b2b77fcf17e7b4da36985",
     "packages": [],
     "packages-dev": [
         {

--- a/config/sage-native-block.php
+++ b/config/sage-native-block.php
@@ -4,17 +4,43 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Sage Native Block Package Configuration
+    | Default Vendor Prefix
     |--------------------------------------------------------------------------
     |
-    | This configuration file is for the Sage Native Block package.
-    | Currently, it does not hold specific settings but provides a place
-    | for future configuration options related to block scaffolding or
-    | management within Sage themes using Acorn.
+    | The default vendor prefix to use when creating blocks without a specified
+    | vendor prefix. This helps maintain consistent naming across your blocks.
     |
     */
+    'default_vendor_prefix' => 'vendor',
 
-    // Example configuration options can be added here in the future.
-    // 'setting' => 'value',
+    /*
+    |--------------------------------------------------------------------------
+    | Block Directory Path
+    |--------------------------------------------------------------------------
+    |
+    | The relative path where block files will be created within your theme.
+    | Default: resources/js/blocks
+    |
+    */
+    'block_directory' => 'resources/js/blocks',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Template Paths
+    |--------------------------------------------------------------------------
+    |
+    | Customize the stub templates used for generating block files.
+    | Set to null to use package defaults.
+    |
+    */
+    'templates' => [
+        'block_json' => null,    // Path to custom block.json template
+        'index_js' => null,      // Path to custom index.js template
+        'editor_jsx' => null,    // Path to custom editor.jsx template
+        'save_jsx' => null,      // Path to custom save.jsx template
+        'editor_css' => null,    // Path to custom editor.css template
+        'style_css' => null,     // Path to custom style.css template
+        'view_js' => null,       // Path to custom view.js template
+    ],
 
 ];


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for CI, enhances the Sage Native Block package with additional configuration options and features, and updates the `laravel/pint` dependency. Below are the key changes grouped by their themes:

### CI/CD Improvements:
* Added a new GitHub Actions workflow (`.github/workflows/main.yml`) to run CI for PHP 8.2. It includes steps for setting up the environment, caching Composer dependencies, and running Pint for code style checks.

### Sage Native Block Enhancements:
* Updated `config/sage-native-block.php` to include new configuration options for default vendor prefix, block directory path, and customizable template paths for block scaffolding.
* Enhanced the `SageNativeBlockCommand` class to support overriding the vendor prefix via a new `--vendor` option and to use the configured block directory path and templates when generating block files. [[1]](diffhunk://#diff-3113d687032ce4862202e8b157df3933e0adc17cf9f3f89ee013f267dac9e612L42-R43) [[2]](diffhunk://#diff-3113d687032ce4862202e8b157df3933e0adc17cf9f3f89ee013f267dac9e612R114-R120) [[3]](diffhunk://#diff-3113d687032ce4862202e8b157df3933e0adc17cf9f3f89ee013f267dac9e612R272-R276) [[4]](diffhunk://#diff-3113d687032ce4862202e8b157df3933e0adc17cf9f3f89ee013f267dac9e612L276-R309)
* Updated the `README.md` with detailed documentation on configuration options, command usage, and customization of block scaffolding templates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R116-R127)

### Dependency Updates:
* Updated the `laravel/pint` dependency in `composer.json` from version `^1.20` to `^1.22` to ensure compatibility with the latest features and fixes.