### PR TITLE
Installation Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ This package helps you create and manage native Gutenberg blocks in your [Sage](
 
 ## Installation
 
-You can install this package with Composer:
+You can install this package with Composer from your Sage 11+ theme root directory (not from the Bedrock root):
 
 ```bash
-composer require imagewize/sage-native-block
+composer require imagewize/sage-native-block --dev
 ```
 
+**NB** You can drop `--dev` but then it will be included in your production build.
 You can publish the config file with:
 
 ```shell


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` file to provide more clarity and flexibility for users.

Documentation improvements:

* Updated the installation instructions to specify that the package should be installed from the Sage 11+ theme root directory, not the Bedrock root.
* Added a note explaining the optional use of the `--dev` flag during installation, clarifying its impact on the production build.