### PR TITLE
README Command Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This will:
 To create a block with a custom name:
 
 ```shell
-$ wp acorn sage-native-block:add-setup my-cool-block
+wp acorn sage-native-block:add-setup my-cool-block
 ```
 
 This will create a block named `vendor/my-cool-block` with all the necessary files.
@@ -62,7 +62,7 @@ This will create a block named `vendor/my-cool-block` with all the necessary fil
 To create a block with a specific vendor prefix:
 
 ```shell
-$ wp acorn sage-native-block:add-setup imagewize/my-cool-block
+wp acorn sage-native-block:add-setup imagewize/my-cool-block
 ```
 
 This creates a block with proper namespace `imagewize/my-cool-block`.
@@ -72,9 +72,9 @@ This creates a block with proper namespace `imagewize/my-cool-block`.
 Use the `--force` flag to skip the confirmation prompt:
 
 ```shell
-$ wp acorn sage-native-block:add-setup --force
-$ wp acorn sage-native-block:add-setup my-block-name --force
-$ wp acorn sage-native-block:add-setup imagewize/custom-block --force
+wp acorn sage-native-block:add-setup --force
+wp acorn sage-native-block:add-setup my-block-name --force
+wp acorn sage-native-block:add-setup imagewize/custom-block --force
 ```
 
 ## Block Structure


### PR DESCRIPTION
This pull request updates the `README.md` file to remove unnecessary `$` symbols from shell command examples, improving clarity and consistency in the documentation.

Documentation updates:

* Removed the ` prefix from command examples in the sections for creating a block with a custom name, a specific vendor prefix, and using the `--force` flag. (`README.md`: [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R55) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L65-R65) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R77)