### PR TITLE
Nynaeve Basic Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-03-23
+
+### Added
+
+- **`nynaeve-basic` Template** - Clean starting point for Nynaeve theme blocks with all project standards baked in
+  - `block.json` uses `imagewize` category, includes `editorScript`, full `supports` (align wide/full, anchor, spacing, color), `align: "full"` default, and margin-reset attribute (`margin-top: 0, margin-bottom: 0`) to prevent WordPress layout gaps
+  - `editor.jsx` ships with `{{BLOCK_CLASS_NAME}}` placeholder, an empty TEMPLATE with inline documentation showing how to import SVG assets via `core/image` blocks (Vite URL import pattern)
+  - `save.jsx` uses `{{BLOCK_CLASS_NAME}}` placeholder and clean `<InnerBlocks.Content />`
+  - `style.css` and `editor.css` use `{{BLOCK_CLASS_NAME}}` placeholder with a note on vertical-only padding (no horizontal padding — WordPress layout handles that via `theme.json`)
+  - Registered in config as first entry under the `nynaeve` category
+
+### Fixed
+
+- **CSS class placeholder in `nynaeve-*` stubs** - `replaceCssClassName()` now handles the `{{BLOCK_CLASS_NAME}}` placeholder used in newer stub files in addition to the legacy `.wp-block-vendor-example-block` selector
+  - Previously, `style.css` and `editor.css` in `nynaeve-*` stubs that used `{{BLOCK_CLASS_NAME}}` were not having their class name replaced on scaffold
+  - Both placeholder styles now work correctly in the same pass
+
 ## [2.0.2] - 2025-11-17
 
 ### Added
@@ -227,7 +244,8 @@ Templates automatically appear in the category selection menu on next run.
 - Configuration documentation
 - Feature overview and examples
 
-[Unreleased]: https://github.com/imagewize/sage-native-block/compare/v2.0.2...HEAD
+[Unreleased]: https://github.com/imagewize/sage-native-block/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/imagewize/sage-native-block/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/imagewize/sage-native-block/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/imagewize/sage-native-block/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/imagewize/sage-native-block/compare/v1.1.0...v2.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,107 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+`sage-native-block` is a Composer package that provides interactive CLI scaffolding for WordPress Gutenberg blocks in [Roots Sage](https://roots.io/sage/) themes. It integrates with Acorn (the Laravel-based framework for Sage) and is invoked via `wp acorn sage-native-block:create` inside a Sage theme.
+
+## Commands
+
+**Code formatting (Laravel Pint):**
+```bash
+composer run pint
+```
+
+**Manual testing inside a Sage theme:**
+```bash
+# Interactive mode
+wp acorn sage-native-block:create
+
+# Non-interactive with template
+wp acorn sage-native-block:create imagewize/my-block --template=basic
+wp acorn sage-native-block:create imagewize/my-block --template=nynaeve-cta --force
+
+# Deprecated alias (still works)
+wp acorn sage-native-block:add-setup imagewize/my-block --template=statistics
+```
+
+**Release tagging:**
+```bash
+git tag -a v2.x.x -m "Release v2.x.x"
+git push origin v2.x.x
+```
+
+## Architecture
+
+### Package Entry Point
+
+`src/Providers/SageNativeBlockServiceProvider.php` registers the Artisan commands and publishes the config. Acorn auto-discovers this provider via `extra.acorn.providers` in `composer.json`.
+
+### Main Command: `SageNativeBlockCommand`
+
+`src/Console/SageNativeBlockCommand.php` is the core of the package. Key execution flow:
+
+1. **Parse input** — block name like `imagewize/my-block` is split into vendor (`imagewize`) and block slug (`my-block`). If no vendor is given, it falls back to the configured default.
+2. **Template selection** — interactive two-step picker (Category → Template) or direct `--template` flag. Auto-discovers custom theme templates from `block-templates/` directories.
+3. **Update `app/setup.php`** — injects block auto-registration code (scans `resources/js/blocks/` for `block.json` files).
+4. **Update `resources/js/editor.js`** — ensures `import.meta.glob('./blocks/**/index.js', { eager: true })` exists.
+5. **Copy and process stubs** — copies 7 files from the selected stub directory, applying placeholder replacements.
+
+The deprecated `SageNativeBlockAddSetupCommand` extends the main command and just shows a deprecation warning before delegating.
+
+### Template System
+
+Templates live in `stubs/` and are registered in `config/sage-native-block.php`:
+
+```
+stubs/
+├── block/              # Basic template (key: "basic")
+├── generic/            # Theme-agnostic templates (innerblocks, two-column, statistics, cta)
+└── themes/
+    └── nynaeve/        # Nynaeve theme-specific templates (keys: "nynaeve-*")
+```
+
+Each template contains exactly 7 files: `block.json`, `index.js`, `editor.jsx`, `save.jsx`, `editor.css`, `style.css`, `view.js`.
+
+**Adding a new template:** create the stub directory with 7 files, then register it in `config/sage-native-block.php` under `templates`.
+
+**Theme-specific templates** follow the key pattern `{theme-name}-{type}` and have a `README.md` documenting required `theme.json` settings (font families, colors, etc.).
+
+### Placeholder Replacement
+
+When stubs are copied, these replacements are applied:
+
+| Placeholder | Replaced with | Files affected |
+|---|---|---|
+| `vendor/example-block` | Full block name (e.g. `imagewize/my-block`) | `block.json` |
+| `'vendor'` (textdomain) | Vendor slug | `block.json` |
+| `{{BLOCK_CLASS_NAME}}` | CSS class (e.g. `wp-block-imagewize-my-block`) | `editor.jsx` |
+| `.wp-block-vendor-example-block` | CSS selector | `style.css`, `editor.css` |
+
+Block output directories use only the block slug (no vendor): `imagewize/my-block` → `resources/js/blocks/my-block/`.
+
+### Configuration (`config/sage-native-block.php`)
+
+- `templates` — map of template key → `name`, `description`, `stub_path`
+- `default_template` — fallback when no `--template` flag is given
+- `typography_presets` — Montserrat/Open Sans font settings used in Nynaeve templates
+- `spacing_presets` — reusable spacing values
+
+### Nynaeve Theme Templates
+
+Nynaeve templates (`stubs/themes/nynaeve/`) are production-ready and differ from generic ones:
+- `block.json` uses `"category": "imagewize"`, full `supports` (align wide/full, anchor, spacing, color), and `"align": "full"` default with margin-reset attribute
+- `editor.jsx` uses `{{BLOCK_CLASS_NAME}}` placeholder (not the legacy CSS class)
+- Require `theme.json` font families (`montserrat`, `open-sans`) and color palette to be defined in the consuming theme
+
+## Git Conventions
+
+- **Atomic commits** — each commit should represent one logical change. Don't bundle unrelated fixes or features.
+- **No Claude references** — commit messages must never mention Claude, AI, or be co-authored by Claude.
+
+## Release Process
+
+1. Update `CHANGELOG.md` with version and changes
+2. Tag: `git tag -a vX.Y.Z -m "Release vX.Y.Z"` and push the tag
+3. Create GitHub release using the CHANGELOG section

--- a/README.md
+++ b/README.md
@@ -154,12 +154,13 @@ Real-world examples from production themes. Currently featuring templates from t
 
 | Template | Description | Use Case |
 |----------|-------------|----------|
+| **nynaeve-basic** | Clean starting point with all Nynaeve standards — correct category, supports, margin reset, SVG image import pattern | **Start here** for any new Nynaeve block |
 | **nynaeve-innerblocks** | Pre-styled with Nynaeve typography | Production-ready container |
 | **nynaeve-two-column** | Card-style layout from Nynaeve | Polished two-column sections |
 | **nynaeve-statistics** | Complete statistics from Nynaeve | Production-ready stats display |
 | **nynaeve-cta** | Styled CTA from Nynaeve theme | Ready-to-use call-to-action |
 
-> 💡 **Tip:** Use generic templates for universal compatibility, or Nynaeve templates if your theme matches its setup. See [`stubs/themes/nynaeve/README.md`](stubs/themes/nynaeve/README.md) for detailed requirements.
+> 💡 **Tip:** Use `nynaeve-basic` as your starting point for all new Nynaeve blocks — it scaffolds with the correct `imagewize` category, `editorScript`, full `supports`, `align: "full"` default, and margin-reset attribute. No manual cleanup needed. See [`stubs/themes/nynaeve/README.md`](stubs/themes/nynaeve/README.md) for detailed requirements.
 
 ### Command Examples
 
@@ -188,6 +189,7 @@ wp acorn sage-native-block:create my-columns --template=two-column --force
 wp acorn sage-native-block:create my-container --template=innerblocks --force
 
 # Nynaeve theme templates (requires Nynaeve theme.json setup)
+wp acorn sage-native-block:create imagewize/my-block --template=nynaeve-basic --force
 wp acorn sage-native-block:create my-stats --template=nynaeve-statistics --force
 wp acorn sage-native-block:create imagewize/my-cta --template=nynaeve-cta --force
 ```

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
   "require-dev": {
     "laravel/pint": "^1.20"
   },
+  "scripts": {
+    "pint": "./vendor/bin/pint"
+  },
   "extra": {
     "acorn": {
       "providers": [

--- a/config/sage-native-block.php
+++ b/config/sage-native-block.php
@@ -61,6 +61,12 @@ return [
         // Nynaeve Theme Templates (by Imagewize)
         // Based on production Nynaeve theme - requires specific theme.json setup
         // See: stubs/themes/nynaeve/README.md for requirements
+        'nynaeve-basic' => [
+            'name' => 'Basic Block',
+            'description' => 'Clean starting point — imagewize category, full supports, margin reset, SVG image import pattern',
+            'stub_path' => 'themes/nynaeve/basic',
+            'category' => 'nynaeve',
+        ],
         'nynaeve-innerblocks' => [
             'name' => 'InnerBlocks',
             'description' => 'From Nynaeve theme - montserrat, open-sans fonts',

--- a/src/Console/SageNativeBlockCommand.php
+++ b/src/Console/SageNativeBlockCommand.php
@@ -59,13 +59,9 @@ class SageNativeBlockCommand extends Command
         parent::__construct();
         $this->files = $files;
     }
-    
+
     /**
      * Resolve the theme path using RootsFilesystem or fallback to WordPress methods
-     *
-     * @param RootsFilesystem $rootsFiles
-     * @param string $relativePath
-     * @return string
      */
     protected function resolvePath(RootsFilesystem $rootsFiles, string $relativePath = ''): string
     {
@@ -77,26 +73,26 @@ class SageNativeBlockCommand extends Command
         } catch (\Exception $e) {
             // Fallback to WordPress methods
         }
-        
+
         // First fallback: WordPress functions
         if (function_exists('get_template_directory')) {
             $themePath = get_template_directory();
-            
-            if (!empty($relativePath)) {
-                return $themePath . '/' . $relativePath;
+
+            if (! empty($relativePath)) {
+                return $themePath.'/'.$relativePath;
             }
-            
+
             return $themePath;
         }
-        
+
         // Last resort: Try to detect the theme path from the command location
         $commandPath = dirname(__DIR__, 5); // Adjust if needed
         $this->warn("Using detected theme path: {$commandPath}");
-        
-        if (!empty($relativePath)) {
-            return $commandPath . '/' . $relativePath;
+
+        if (! empty($relativePath)) {
+            return $commandPath.'/'.$relativePath;
         }
-        
+
         return $commandPath;
     }
 
@@ -108,7 +104,7 @@ class SageNativeBlockCommand extends Command
         // Interactive mode: prompt for block name if not provided
         $blockNameInput = $this->argument('blockName');
 
-        if (!$blockNameInput) {
+        if (! $blockNameInput) {
             $this->newLine();
             $this->line('<fg=cyan>Welcome to Sage Native Block Creator!</>');
             $this->line('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
@@ -118,24 +114,25 @@ class SageNativeBlockCommand extends Command
 
             if (empty($blockNameInput)) {
                 $this->error('Block name is required.');
+
                 return static::FAILURE;
             }
         }
 
         // Ensure block name always has a vendor prefix
-        if (!str_contains($blockNameInput, '/')) {
+        if (! str_contains($blockNameInput, '/')) {
             $defaultVendor = 'vendor';
 
             // Only prompt for vendor if in interactive mode
-            if (!$this->argument('blockName')) {
+            if (! $this->argument('blockName')) {
                 $vendor = $this->ask("Enter vendor prefix (leave empty for '{$defaultVendor}')");
-                $vendor = !empty($vendor) ? $vendor : $defaultVendor;
+                $vendor = ! empty($vendor) ? $vendor : $defaultVendor;
             } else {
                 $vendor = $defaultVendor;
                 $this->comment("No vendor prefix provided. Using default: '{$vendor}'");
             }
 
-            $fullBlockName = $vendor . '/' . $blockNameInput;
+            $fullBlockName = $vendor.'/'.$blockNameInput;
         } else {
             $fullBlockName = $blockNameInput;
         }
@@ -152,8 +149,9 @@ class SageNativeBlockCommand extends Command
         }
 
         // Validate template exists
-        if (!$this->isValidTemplate($template)) {
+        if (! $this->isValidTemplate($template)) {
             $this->error("Template '{$template}' not found in configuration.");
+
             return static::FAILURE;
         }
 
@@ -177,7 +175,7 @@ class SageNativeBlockCommand extends Command
         $setupPath = $this->resolvePath($rootsFiles, 'app/setup.php');
 
         if (! $this->files->exists($setupPath)) {
-            $this->error("Error: Theme setup file not found at app/setup.php");
+            $this->error('Error: Theme setup file not found at app/setup.php');
 
             return static::FAILURE;
         }
@@ -203,7 +201,7 @@ class SageNativeBlockCommand extends Command
 
         try {
             // Append the code to the file only if it's not already there
-            if (!$setupExists) {
+            if (! $setupExists) {
                 $backupPath = $setupPath.'.backup-'.date('Y-m-d-His');
                 $this->files->copy($setupPath, $backupPath);
 
@@ -214,6 +212,7 @@ class SageNativeBlockCommand extends Command
                     if ($backupPath) {
                         $this->files->copy($backupPath, $setupPath);
                     }
+
                     return static::FAILURE;
                 }
             } else {
@@ -234,12 +233,13 @@ class SageNativeBlockCommand extends Command
             // Copy block template files using the full name for replacements and directory name for path
             $filesCopied = $this->copyBlockStubs($rootsFiles, $fullBlockName, $directoryBlockName, $template);
 
-            if (!$filesCopied) {
-                 // If copying fails, potentially revert setup.php if it was modified in this run
-                 if ($backupPath && $this->files->exists($backupPath)) {
+            if (! $filesCopied) {
+                // If copying fails, potentially revert setup.php if it was modified in this run
+                if ($backupPath && $this->files->exists($backupPath)) {
                     $this->error('  ✗ Failed to copy files. Reverting changes...');
                     $this->files->copy($backupPath, $setupPath);
                 }
+
                 return static::FAILURE;
             }
 
@@ -272,8 +272,10 @@ class SageNativeBlockCommand extends Command
     {
         if (str_contains($fullBlockName, '/')) {
             $parts = explode('/', $fullBlockName);
+
             return end($parts);
         }
+
         return $fullBlockName;
     }
 
@@ -282,29 +284,29 @@ class SageNativeBlockCommand extends Command
      */
     protected function getBlockRegistrationCode(): string
     {
-        return <<<PHP
+        return <<<'PHP'
 
 /**
  * Register block types using block.json metadata from the theme's blocks directory.
  * This function will scan the 'resources/js/blocks' directory for block.json files.
  */
 add_action('init', function () {
-    \$blocks_dir = get_template_directory() . '/resources/js/blocks';
-    if (!is_dir(\$blocks_dir)) {
+    $blocks_dir = get_template_directory() . '/resources/js/blocks';
+    if (!is_dir($blocks_dir)) {
         return;
     }
 
-    \$block_folders = scandir(\$blocks_dir);
+    $block_folders = scandir($blocks_dir);
 
-    foreach (\$block_folders as \$folder) {
-        if (\$folder === '.' || \$folder === '..') {
+    foreach ($block_folders as $folder) {
+        if ($folder === '.' || $folder === '..') {
             continue;
         }
 
-        \$block_json_path = \$blocks_dir . '/' . \$folder . '/block.json';
+        $block_json_path = $blocks_dir . '/' . $folder . '/block.json';
 
-        if (file_exists(\$block_json_path)) {
-            register_block_type(\$block_json_path);
+        if (file_exists($block_json_path)) {
+            register_block_type($block_json_path);
         }
     }
 }, 10);
@@ -325,15 +327,16 @@ PHP;
 
             // Check if this is a theme template (from block-templates/)
             if ($this->isThemeTemplate($template)) {
-                $stubsDir = get_template_directory() . '/block-templates/' . $stubPath;
+                $stubsDir = get_template_directory().'/block-templates/'.$stubPath;
             } else {
                 // Package template - use stubs directory
-                $stubsDir = dirname(__DIR__, 2) . '/stubs/' . $stubPath;
+                $stubsDir = dirname(__DIR__, 2).'/stubs/'.$stubPath;
             }
 
             // Validate the directory exists
-            if (!$this->files->isDirectory($stubsDir)) {
+            if (! $this->files->isDirectory($stubsDir)) {
                 $this->error("Template directory not found: {$stubsDir}");
+
                 return false;
             }
 
@@ -412,7 +415,7 @@ PHP;
             return false;
         }
     }
-    
+
     /**
      * Replace placeholders in block.json content with the provided full block name.
      */
@@ -422,6 +425,7 @@ PHP;
 
         if (json_last_error() !== JSON_ERROR_NONE) {
             $this->warn('Could not parse block.json stub, using it as is.');
+
             return $content;
         }
 
@@ -434,8 +438,8 @@ PHP;
             $actualBlockName = $parts[1];
         } else {
             // This case should ideally not be reached due to logic in handle()
-             $this->warn("Block name '{$fullBlockName}' unexpectedly lacks a vendor prefix during replacement. Defaulting vendor to 'vendor'.");
-             $actualBlockName = $fullBlockName; // Use the full name as the actual name
+            $this->warn("Block name '{$fullBlockName}' unexpectedly lacks a vendor prefix during replacement. Defaulting vendor to 'vendor'.");
+            $actualBlockName = $fullBlockName; // Use the full name as the actual name
         }
 
         // Update the name field
@@ -450,25 +454,25 @@ PHP;
 
         // Update textdomain to match the determined vendor
         if (isset($data['textdomain'])) { // Check if textdomain key exists in stub
-             $data['textdomain'] = $vendor;
+            $data['textdomain'] = $vendor;
         }
 
         // Update the className default
         if (isset($data['attributes']['className']['default'])) {
-            $className = 'wp-block-' . str_replace('/', '-', $fullBlockName);
+            $className = 'wp-block-'.str_replace('/', '-', $fullBlockName);
             $data['attributes']['className']['default'] = $className;
         }
 
         return json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
     }
-    
+
     /**
      * Replace example CSS class name with the generated class name based on the full block name.
      */
     protected function replaceCssClassName(string $content, string $fullBlockName): string
     {
         // Generate class name like wp-block-vendor-block-name or wp-block-block-name
-        $className = 'wp-block-' . str_replace('/', '-', $fullBlockName);
+        $className = 'wp-block-'.str_replace('/', '-', $fullBlockName);
 
         // Replace {{BLOCK_CLASS_NAME}} placeholder (used in nynaeve-* stubs)
         $content = str_replace('{{BLOCK_CLASS_NAME}}', $className, $content);
@@ -478,13 +482,14 @@ PHP;
 
         return $content;
     }
-    
+
     /**
      * Replace example CSS class name with the generated class name in JS files.
      */
     protected function replaceJsClassName(string $content, string $fullBlockName): string
     {
-        $className = 'wp-block-' . str_replace('/', '-', $fullBlockName);
+        $className = 'wp-block-'.str_replace('/', '-', $fullBlockName);
+
         // Replace the placeholder class literal.
         return str_replace('.wp-block-vendor-example-block', ".{$className}", $content);
     }
@@ -494,7 +499,8 @@ PHP;
      */
     protected function replaceEditorClassName(string $content, string $fullBlockName): string
     {
-        $className = 'wp-block-' . str_replace('/', '-', $fullBlockName);
+        $className = 'wp-block-'.str_replace('/', '-', $fullBlockName);
+
         // Replace the {{BLOCK_CLASS_NAME}} placeholder
         return str_replace('{{BLOCK_CLASS_NAME}}', $className, $content);
     }
@@ -522,13 +528,14 @@ domReady(() => {
 });
 JS; // Ensure this is at the start of the line with no preceding whitespace
             $this->files->put($jsPath, $initialContent);
+
             return null; // Created new file
         } else {
             $jsContent = $this->files->get($jsPath);
 
             $globPattern = './blocks/**/index.js';
             // Use regex for a more robust check of the import line existence
-            if (! preg_match('/import\.meta\.glob\(\s*[\'"]' . preg_quote($globPattern, '/') . '[\'"]/', $jsContent)) {
+            if (! preg_match('/import\.meta\.glob\(\s*[\'"]'.preg_quote($globPattern, '/').'[\'"]/', $jsContent)) {
                 // Use NOWDOC for the code to add
                 $jsToAdd = <<<'JS'
 
@@ -539,7 +546,8 @@ import.meta.glob('./blocks/**/index.js', { eager: true });
 
 JS; // Ensure this is at the start of the line with no preceding whitespace
                 // Prepend the import code to the existing content
-                $this->files->put($jsPath, $jsToAdd . $jsContent);
+                $this->files->put($jsPath, $jsToAdd.$jsContent);
+
                 return true; // Added import
             } else {
                 return false; // Already exists
@@ -557,7 +565,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
 
         // If config is not loaded (returns null or empty), load directly from package
         if ($templates === null || empty($templates)) {
-            $configPath = dirname(__DIR__, 2) . '/config/sage-native-block.php';
+            $configPath = dirname(__DIR__, 2).'/config/sage-native-block.php';
 
             if (file_exists($configPath)) {
                 $config = require $configPath;
@@ -577,7 +585,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
 
         // If config is not loaded, load directly from package
         if ($default === null) {
-            $configPath = dirname(__DIR__, 2) . '/config/sage-native-block.php';
+            $configPath = dirname(__DIR__, 2).'/config/sage-native-block.php';
 
             if (file_exists($configPath)) {
                 $config = require $configPath;
@@ -608,7 +616,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
         $templates = $this->getTemplatesConfig();
         foreach ($templates as $template) {
             if (isset($template['category']) &&
-                !in_array($template['category'], ['basic', 'generic'])) {
+                ! in_array($template['category'], ['basic', 'generic'])) {
                 $categoryNames[$template['category']] = true;
             }
         }
@@ -617,7 +625,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
         $themeTemplates = $this->getThemeTemplates();
         foreach ($themeTemplates as $templateData) {
             $category = $templateData['category'] ?? 'custom';
-            if (!in_array($category, ['basic', 'generic'])) {
+            if (! in_array($category, ['basic', 'generic'])) {
                 $categoryNames[$category] = true;
             }
         }
@@ -639,9 +647,9 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
     protected function getThemeTemplates(): array
     {
         $themeTemplates = [];
-        $blockTemplatesDir = get_template_directory() . '/block-templates';
+        $blockTemplatesDir = get_template_directory().'/block-templates';
 
-        if (!$this->files->isDirectory($blockTemplatesDir)) {
+        if (! $this->files->isDirectory($blockTemplatesDir)) {
             return $themeTemplates;
         }
 
@@ -649,10 +657,10 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
 
         foreach ($templateFolders as $templateFolder) {
             $templateName = basename($templateFolder);
-            $blockJsonPath = $templateFolder . '/block.json';
+            $blockJsonPath = $templateFolder.'/block.json';
 
             // Only include if block.json exists
-            if (!$this->files->exists($blockJsonPath)) {
+            if (! $this->files->exists($blockJsonPath)) {
                 continue;
             }
 
@@ -676,9 +684,9 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
      */
     protected function loadTemplateMetadata(string $templateFolder): array
     {
-        $metadataPath = $templateFolder . '/template-meta.json';
+        $metadataPath = $templateFolder.'/template-meta.json';
 
-        if (!$this->files->exists($metadataPath)) {
+        if (! $this->files->exists($metadataPath)) {
             return [];
         }
 
@@ -688,12 +696,14 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
 
             if (json_last_error() !== JSON_ERROR_NONE) {
                 $this->warn("Invalid JSON in {$metadataPath}. Using defaults.");
+
                 return [];
             }
 
             return $metadata;
         } catch (\Exception $e) {
             $this->warn("Could not read {$metadataPath}. Using defaults.");
+
             return [];
         }
     }
@@ -706,6 +716,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
     {
         $words = explode('-', $name);
         $words = array_map('ucfirst', $words);
+
         return implode(' ', $words);
     }
 
@@ -718,6 +729,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
 
         if (empty($categories)) {
             $this->warn('No template categories found. Using basic.');
+
             return 'basic';
         }
 
@@ -750,6 +762,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
 
         if (empty($allTemplates)) {
             $this->warn('No templates found. Using default.');
+
             return $this->getDefaultTemplate();
         }
 
@@ -762,6 +775,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
 
         if (empty($allTemplates)) {
             $this->warn("No templates found for category '{$category}'. Using default.");
+
             return $this->getDefaultTemplate();
         }
 
@@ -839,6 +853,7 @@ JS; // Ensure this is at the start of the line with no preceding whitespace
     protected function isThemeTemplate(string $template): bool
     {
         $themeTemplates = $this->getThemeTemplates();
+
         return isset($themeTemplates[$template]);
     }
 }

--- a/src/Console/SageNativeBlockCommand.php
+++ b/src/Console/SageNativeBlockCommand.php
@@ -469,9 +469,14 @@ PHP;
     {
         // Generate class name like wp-block-vendor-block-name or wp-block-block-name
         $className = 'wp-block-' . str_replace('/', '-', $fullBlockName);
-        
-        // Replace the placeholder class. No need to escape the replacement string.
-        return preg_replace('/\.wp-block-vendor-example-block/', ".{$className}", $content);
+
+        // Replace {{BLOCK_CLASS_NAME}} placeholder (used in nynaeve-* stubs)
+        $content = str_replace('{{BLOCK_CLASS_NAME}}', $className, $content);
+
+        // Replace legacy .wp-block-vendor-example-block placeholder (used in older stubs)
+        $content = preg_replace('/\.wp-block-vendor-example-block/', ".{$className}", $content);
+
+        return $content;
     }
     
     /**

--- a/src/Providers/SageNativeBlockServiceProvider.php
+++ b/src/Providers/SageNativeBlockServiceProvider.php
@@ -3,8 +3,8 @@
 namespace Imagewize\SageNativeBlockPackage\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Imagewize\SageNativeBlockPackage\Console\SageNativeBlockCommand;
 use Imagewize\SageNativeBlockPackage\Console\SageNativeBlockAddSetupCommand;
+use Imagewize\SageNativeBlockPackage\Console\SageNativeBlockCommand;
 
 class SageNativeBlockServiceProvider extends ServiceProvider
 {

--- a/stubs/themes/nynaeve/basic/block.json
+++ b/stubs/themes/nynaeve/basic/block.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://schemas.wp.org/trunk/block.json",
+    "apiVersion": 3,
+    "name": "vendor/example-block",
+    "title": "Example Block",
+    "category": "imagewize",
+    "icon": "grid-view",
+    "description": "Block description.",
+    "keywords": [],
+    "example": {},
+    "textdomain": "vendor",
+    "editorScript": "file:./index.js",
+    "editorStyle": "file:./editor.css",
+    "style": "file:./style.css",
+    "viewScript": "file:./view.js",
+    "supports": {
+        "align": ["wide", "full"],
+        "anchor": true,
+        "spacing": {
+            "margin": true,
+            "padding": true
+        },
+        "color": {
+            "background": true,
+            "text": true
+        }
+    },
+    "attributes": {
+        "align": {
+            "type": "string",
+            "default": "full"
+        },
+        "style": {
+            "type": "object",
+            "default": {
+                "spacing": {
+                    "margin": { "top": "0", "bottom": "0" }
+                }
+            }
+        }
+    }
+}

--- a/stubs/themes/nynaeve/basic/editor.css
+++ b/stubs/themes/nynaeve/basic/editor.css
@@ -1,0 +1,3 @@
+.{{BLOCK_CLASS_NAME}} {
+  /* Editor-only styles */
+}

--- a/stubs/themes/nynaeve/basic/editor.jsx
+++ b/stubs/themes/nynaeve/basic/editor.jsx
@@ -1,0 +1,34 @@
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Define your block's default content structure.
+ * Use native WordPress blocks (core/heading, core/paragraph, core/image, etc.)
+ * Import SVG assets from resources/images/ and pass as `url` to core/image blocks.
+ *
+ * Example:
+ *   import myIcon from '../../../images/icons/my-icon.svg';
+ *   ['core/image', { url: myIcon, alt: 'My Icon', width: 28, height: 28, sizeSlug: 'full', linkDestination: 'none' }],
+ */
+const TEMPLATE = [
+  ['core/heading', {
+    level: 2,
+    content: 'Block Heading',
+    fontFamily: 'montserrat',
+    style: { typography: { fontWeight: '800' } },
+  }],
+  ['core/paragraph', {
+    content: 'Block content goes here.',
+  }],
+];
+
+export default function Edit() {
+  const blockProps = useBlockProps({
+    className: '{{BLOCK_CLASS_NAME}}',
+  });
+
+  return (
+    <div {...blockProps}>
+      <InnerBlocks template={TEMPLATE} templateLock={false} />
+    </div>
+  );
+}

--- a/stubs/themes/nynaeve/basic/index.js
+++ b/stubs/themes/nynaeve/basic/index.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './editor';
+import Save from './save';
+
+/**
+ * Register the block
+ */
+registerBlockType(metadata.name, {
+  ...metadata,
+  edit: Edit,
+  save: Save,
+});

--- a/stubs/themes/nynaeve/basic/save.jsx
+++ b/stubs/themes/nynaeve/basic/save.jsx
@@ -1,0 +1,13 @@
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+export default function Save() {
+  const blockProps = useBlockProps.save({
+    className: '{{BLOCK_CLASS_NAME}}',
+  });
+
+  return (
+    <div {...blockProps}>
+      <InnerBlocks.Content />
+    </div>
+  );
+}

--- a/stubs/themes/nynaeve/basic/style.css
+++ b/stubs/themes/nynaeve/basic/style.css
@@ -1,0 +1,7 @@
+.{{BLOCK_CLASS_NAME}} {
+  /* Block styles — vertical padding only, no horizontal padding.
+   * WordPress layout handles horizontal spacing automatically via theme.json.
+   * See: docs/CONTENT-WIDTH-AND-LAYOUT.md
+   */
+  padding: 80px 0;
+}

--- a/stubs/themes/nynaeve/basic/view.js
+++ b/stubs/themes/nynaeve/basic/view.js
@@ -1,0 +1,29 @@
+/**
+ * View script for the block.
+ *
+ * This file handles any client-side functionality needed for the block
+ * on the frontend of the site.
+ */
+
+(function() {
+    // Select all instances of this block on the page
+    const blocks = document.querySelectorAll('.wp-block-vendor-example-block');
+
+    // Function to initialize a block
+    function initBlock(block) {
+      // Example: Add counter animation for statistics
+      const stats = block.querySelectorAll('.statistics-row .wp-block-heading');
+
+      stats.forEach(function(stat) {
+        // Add your counter animation logic here
+        // Example: Animate numbers when scrolling into view
+      });
+    }
+
+    // Initialize each block found
+    if (blocks.length) {
+      blocks.forEach(function(block) {
+        initBlock(block);
+      });
+    }
+  })();


### PR DESCRIPTION
This release introduces the `nynaeve-basic` block template, a production-ready Gutenberg block scaffold tailored for the Nynaeve theme. The template ships as a complete 7-file stub set and integrates with the existing template discovery and placeholder replacement system. A new `{{BLOCK_CLASS_NAME}}` placeholder was added to the stub processing pipeline, enabling dynamic CSS class injection into `editor.jsx` at scaffold time. The release also formalizes developer tooling with a Pint code style script and adds `CLAUDE.md` project instructions for AI-assisted development workflows.

**New Template: nynaeve-basic**

- Added `stubs/themes/nynaeve/basic/` containing all 7 required stub files (`block.json`, `index.js`, `editor.jsx`, `save.jsx`, `editor.css`, `style.css`, `view.js`), following the established Nynaeve conventions: `"category": "imagewize"`, full `supports` declarations, and `"align": "full"` default with margin-reset attribute.
- Registered the template in `config/sage-native-block.php` under the key `nynaeve-basic`, making it available via both the interactive picker and the `--template=nynaeve-basic` flag.

**Placeholder Replacement and Command Enhancements**

- Extended `SageNativeBlockCommand` to replace `{{BLOCK_CLASS_NAME}}` with the computed CSS class (e.g., `wp-block-imagewize-my-block`) during stub copying, addressing the requirement for dynamic class names in Nynaeve `editor.jsx` files.
- Updated `SageNativeBlockServiceProvider` as needed to reflect command and configuration changes.

**Developer Tooling and Documentation**

- Added a `pint` script to `composer.json` for one-command Laravel Pint formatting, and applied Pint style fixes across the codebase for consistent code style.
- Added `CLAUDE.md` documenting architecture, template structure, placeholder replacements, and git conventions for use with Claude Code.
- Updated `README.md` and `CHANGELOG.md` to document the `nynaeve-basic` template, the new placeholder, and the v2.1.0 release.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/CHANGELOG.md) (Modified)
- [`README.md`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/README.md) (Modified)
- [`composer.json`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/composer.json) (Modified)
- [`config/sage-native-block.php`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/config/sage-native-block.php) (Modified)
- [`src/Console/SageNativeBlockCommand.php`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/src/Console/SageNativeBlockCommand.php) (Modified)
- [`src/Providers/SageNativeBlockServiceProvider.php`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/src/Providers/SageNativeBlockServiceProvider.php) (Modified)
- [`CLAUDE.md`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/CLAUDE.md) (Added)
- [`stubs/themes/nynaeve/basic/block.json`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/stubs/themes/nynaeve/basic/block.json) (Added)
- [`stubs/themes/nynaeve/basic/editor.css`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/stubs/themes/nynaeve/basic/editor.css) (Added)
- [`stubs/themes/nynaeve/basic/editor.jsx`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/stubs/themes/nynaeve/basic/editor.jsx) (Added)
- [`stubs/themes/nynaeve/basic/index.js`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/stubs/themes/nynaeve/basic/index.js) (Added)
- [`stubs/themes/nynaeve/basic/save.jsx`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/stubs/themes/nynaeve/basic/save.jsx) (Added)
- [`stubs/themes/nynaeve/basic/style.css`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/stubs/themes/nynaeve/basic/style.css) (Added)
- [`stubs/themes/nynaeve/basic/view.js`](https://github.com/imagewize/sage-native-block/blob/nynaeve-basic-template/stubs/themes/nynaeve/basic/view.js) (Added)