### PR TITLE
Patch/editor Script Removal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,12 @@ Nynaeve templates (`stubs/themes/nynaeve/`) are production-ready and differ from
 - `editor.jsx` uses `{{BLOCK_CLASS_NAME}}` placeholder (not the legacy CSS class)
 - Require `theme.json` font families (`montserrat`, `open-sans`) and color palette to be defined in the consuming theme
 
+### `editorScript` must NOT be in block.json (CRITICAL)
+
+Do **not** add `"editorScript": "file:./index.js"` to any stub's `block.json`. This is a `@wordpress/scripts` (webpack) convention. Sage themes use **Vite**, which bundles all blocks via `import.meta.glob('./blocks/**/index.js', { eager: true })` in `editor.js`. Adding `editorScript` causes WordPress to serve the raw unbundled source file to the browser, which fails with a syntax error (`Unexpected token '{'`) because browsers cannot resolve bare `@wordpress/*` imports or parse `.jsx` extensions.
+
+**Correct:** only `"editorStyle"`, `"style"`, and `"viewScript"` fields belong in stub `block.json` files.
+
 ## Git Conventions
 
 - **Atomic commits** — each commit should represent one logical change. Don't bundle unrelated fixes or features.

--- a/stubs/themes/nynaeve/basic/block.json
+++ b/stubs/themes/nynaeve/basic/block.json
@@ -9,7 +9,6 @@
     "keywords": [],
     "example": {},
     "textdomain": "vendor",
-    "editorScript": "file:./index.js",
     "editorStyle": "file:./editor.css",
     "style": "file:./style.css",
     "viewScript": "file:./view.js",


### PR DESCRIPTION
This patch removes an incorrect `editorScript` field from the `stubs/themes/nynaeve/basic/block.json` stub and formalizes the prohibition as a documented rule. Sage themes use Vite for bundling, which relies on `import.meta.glob('./blocks/**/index.js', { eager: true })` in `editor.js` to load all blocks — adding `editorScript` causes WordPress to serve the raw, unbundled source file directly to the browser, resulting in a `Unexpected token '{'` syntax error because bare `@wordpress/*` imports and `.jsx` extensions cannot be resolved without a build step. The fix ensures the stub only declares `editorStyle`, `style`, and `viewScript` fields, aligning it with all other templates in the package. Version 2.1.1 is recorded in the changelog to track this correction.

**Bug Fix — editorScript Removal:**
- Removed `"editorScript": "file:./index.js"` from `stubs/themes/nynaeve/basic/block.json`, eliminating the runtime syntax error that occurred when WordPress attempted to serve the unbundled JSX file directly.
- This stub was the only remaining template with the erroneous field, making it inconsistent with the rest of the template library.

**Documentation and Developer Guidance:**
- Added a dedicated "editorScript must NOT be in block.json (CRITICAL)" section to `CLAUDE.md`, explaining both the rule and the technical reason: Vite-based Sage themes require glob-based bundling rather than per-block `editorScript` declarations.
- The explanation covers the exact failure mode (bare import resolution and `.jsx` parsing), providing enough context for contributors to avoid reintroducing the issue in new stubs or templates.

**Release and Changelog:**
- Added a v2.1.1 entry to `CHANGELOG.md` documenting this as a targeted bug fix release with no breaking changes or feature additions.

**Files Changed:**

- [`CHANGELOG.md`](https://github.com/imagewize/sage-native-block/blob/patch/editor-script-removal/CHANGELOG.md) (Modified)
- [`CLAUDE.md`](https://github.com/imagewize/sage-native-block/blob/patch/editor-script-removal/CLAUDE.md) (Modified)
- [`stubs/themes/nynaeve/basic/block.json`](https://github.com/imagewize/sage-native-block/blob/patch/editor-script-removal/stubs/themes/nynaeve/basic/block.json) (Modified)