### PR TITLE
Add v2.1.1 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-04-03
+
+### Fixed
+
+- **`editorScript` removed from `nynaeve-basic` stub** — `block.json` incorrectly included `"editorScript": "file:./index.js"`, a `@wordpress/scripts` (webpack) convention incompatible with Vite-based Sage themes. WordPress would serve the raw unbundled source file, causing a browser syntax error (`Unexpected token '{'`) on bare `@wordpress/*` imports.
+
 ## [2.1.0] - 2026-03-23
 
 ### Added
@@ -244,7 +250,8 @@ Templates automatically appear in the category selection menu on next run.
 - Configuration documentation
 - Feature overview and examples
 
-[Unreleased]: https://github.com/imagewize/sage-native-block/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/imagewize/sage-native-block/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/imagewize/sage-native-block/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/imagewize/sage-native-block/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/imagewize/sage-native-block/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/imagewize/sage-native-block/compare/v2.0.0...v2.0.1


### PR DESCRIPTION
Patch release: remove editorScript from nynaeve-basic block.json stub, which caused WordPress to serve the raw unbundled source file when using Vite-based Sage themes.